### PR TITLE
Fix token parameter in diarize_audio method, adapted to speaker-diarization 3.1 and speaker-community 1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -34,7 +34,7 @@ class SpeakerDiarizationNode:
 
     def diarize_audio(self, audio: dict, hf_token: str) -> List[Dict[str, Any]]:
 
-        pipeline = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=hf_token)
+        pipeline = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", token=hf_token)
         
         audio_save_path = os.path.join(os.getcwd() , "input" , f"{uuid.uuid1()}.wav")
         
@@ -42,9 +42,10 @@ class SpeakerDiarizationNode:
             0), audio["sample_rate"])
         
         diarization = pipeline(audio_save_path)
+        annotation = diarization.speaker_diarization
         
         speaker_segments = []
-        for turn, _, speaker in diarization.itertracks(yield_label=True):
+        for turn, _, speaker in annotation.itertracks(yield_label=True):
             print( f"start : {turn.start}, end: {turn.end}, speaker: {speaker}")
             speaker_segments.append({
                 'start': turn.start,


### PR DESCRIPTION
Fix token parameter in diarize_audio method, adapted to speaker-diarization 3.1 and speaker-community 1

Applied fix according to https://stackoverflow.com/questions/77736028/whisper-and-pyannote-3-1-attributeerror-list-object-has-no-attribute-get